### PR TITLE
Fix draw_cell coordinates and resize window

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -4,15 +4,15 @@
 
 int main(void)
 {
-    const int screenWidth = 640;
-    const int screenHeight = 400;
+    Renderer rend;
+    Renderer_Init(&rend, "assets/bzzt_font_8x16.png");
+
+    World *world = world_create("New World");
+    const int screenWidth = world->boards[world->boards_current]->width * rend.glyph_w;
+    const int screenHeight = world->boards[world->boards_current]->height * rend.glyph_h;
 
     InitWindow(screenWidth, screenHeight, "Bzzt - prototype");
     SetTargetFPS(60);
-
-    World *world = world_create("New World");
-    Renderer rend;
-    Renderer_Init(&rend, "assets/bzzt_font_8x16.png");
 
     while (!WindowShouldClose())
     {

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -35,8 +35,8 @@ static void draw_cell(Renderer *r, int cellX, int cellY, unsigned char glyph, Co
     Color rb = (Color){bg.r, bg.g, bg.b, 255};
 
     Rectangle dst = {
-        cellX,
-        cellY,
+        cellX * r->glyph_w,
+        cellY * r->glyph_h,
         r->glyph_w,
         r->glyph_h};
 


### PR DESCRIPTION
## Summary
- update renderer's draw_cell to scale screen coordinates
- size the window based on board dimensions and glyph size

## Testing
- `gcc src/*.c -o bzzt -lraylib` *(fails: `raylib.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686c65e7800c832ba3f54475e6e76d8d